### PR TITLE
- fixed cannot run require('resty.mongol') under init_by_lua* because ng...

### DIFF
--- a/lib/resty/mongol/ll.lua
+++ b/lib/resty/mongol/ll.lua
@@ -31,7 +31,6 @@ local num_to_le_uint = function ( n , bytes )
 	for i=1 , bytes do
 		b [ i ] , n = n % 2^8 , floor ( n / 2^8 )
 	end
-	assert ( n == 0 )
 	return strchar ( unpack ( b ) )
 end
 local num_to_le_int = function ( n , bytes )
@@ -57,7 +56,6 @@ local num_to_be_uint = function ( n , bytes )
 	for i=bytes , 1 , -1 do
 		b [ i ] , n = n % 2^8 , floor ( n / 2^8 )
 	end
-	assert ( n == 0 )
 	return strchar ( unpack ( b ) )
 end
 


### PR DESCRIPTION
...x.var.pid cannot access yet on that phase
- fixed some pid's value may crashed by assert
