### PR TITLE
Truncate pid to 2 bytes

### DIFF
--- a/lib/resty/mongol/object_id.lua
+++ b/lib/resty/mongol/object_id.lua
@@ -53,7 +53,7 @@ else
 end
 machineid = ngx.md5_bin(machineid):sub(1, 3)
 
-local pid = num_to_le_uint(ngx.var.pid, 2)
+local pid = num_to_le_uint(bit.band(ngx.var.pid, 0xFFFF), 2)
 
 local inc = 0
 local function generate_id ( )


### PR DESCRIPTION
Mac OS X pids go up to 99999 as of Leopard, which causes an assertion in
num_to_le_uint.
