### PR TITLE
conn:set_timeout API return nil when sucess.

### DIFF
--- a/lib/resty/mongol/init.lua
+++ b/lib/resty/mongol/init.lua
@@ -85,7 +85,8 @@ function connmethods:set_timeout(timeout)
         return nil, "not initialized"
     end
 
-    return sock:settimeout(timeout)
+    sock:settimeout(timeout)
+    return true, "sucucess"
 end
 
 function connmethods:set_keepalive(...)


### PR DESCRIPTION
the tcpsocket:settimeout did NOT return anything. so the return value of conn:set_timeout is nil, which is the same as the return-value of a faillure(nil, "xxx").

Refer: lua-nginx-module source file `ngx_http_lua_socket_tcp.c`. In
function `ngx_http_lua_socket_tcp_settimeout`, this func return 0.
To lua C, this means not return value provided.
