### PR TITLE
Fixed typo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@ lua-resty-mongol - Lua Mongodb driver for ngx_lua base on the cosocket API
 
 Thanks to project Mongol by daurnimator
 
-Dependancies
+Dependencies
 ======
 
 luajit(or `attempt to yield across metamethod/C-call boundary error` will be produced.)


### PR DESCRIPTION
Hello! While searching for an nginx + Lua + MongoDB solution, I happened across your project and noticed a typo ("dependancies" should have been spelled as "dependencies"). It's no big deal, but I like to help out :-)
