### PR TITLE
fix bug that not all records are returned when num_each_query has been s...

### DIFF
--- a/lib/resty/mongol/bson.lua
+++ b/lib/resty/mongol/bson.lua
@@ -66,11 +66,7 @@ local function read_document ( get , numerical )
 				error ( f:byte ( ) )
 			end
 		elseif op == "\9" then -- UTC datetime milliseconds
-			sec = le_uint_to_num ( get ( 8 ) , 1 , 8 )
-            v = {}
-            v.sec = sec/1000
-            v.usec= sec % 1000
-			--v = le_uint_to_num ( get ( 8 ) , 1 , 8 )
+			v = le_uint_to_num ( get ( 8 ) , 1 , 8 )
 		elseif op == "\10" then -- Null
 			v = nil
 		elseif op == "\16" then --int32

--- a/lib/resty/mongol/bson.lua
+++ b/lib/resty/mongol/bson.lua
@@ -66,7 +66,11 @@ local function read_document ( get , numerical )
 				error ( f:byte ( ) )
 			end
 		elseif op == "\9" then -- UTC datetime milliseconds
-			v = le_uint_to_num ( get ( 8 ) , 1 , 8 )
+			sec = le_uint_to_num ( get ( 8 ) , 1 , 8 )
+            v = {}
+            v.sec = sec/1000
+            v.usec= sec % 1000
+			--v = le_uint_to_num ( get ( 8 ) , 1 , 8 )
 		elseif op == "\10" then -- Null
 			v = nil
 		elseif op == "\16" then --int32
@@ -78,9 +82,14 @@ local function read_document ( get , numerical )
 		else
 			error ( "Unknown BSON type: " .. strbyte ( op ) )
 		end
-
+        
 		if numerical then
-			t [ tonumber ( e_name ) ] = v
+			local n_name = tonumber(e_name)
+			if (n_name>0) and (not t[n_name])  then
+				t[n_name] = v
+			else
+				t [ n_name + 1 ] = v
+			end
 		else
 			t [ e_name ] = v
 		end
@@ -186,10 +195,10 @@ function to_bson(ob)
 	elseif onlyarray then
 		local r = { }
 
-		local low = 0
+		local low = 1
 		--if seen_n [ 0 ] then low = 0 end
 		for i=low , high_n do
-			r [ i ] = pack ( i , seen_n [ i ] )
+			r [ i ] = pack ( i-1 , seen_n [ i ] )
 		end
 
 		m = t_concat ( r , "" , low , high_n )

--- a/lib/resty/mongol/cursor.lua
+++ b/lib/resty/mongol/cursor.lua
@@ -19,6 +19,7 @@ local function new_cursor(col, query, returnfields, num_each_query)
 
             done = false ;
             i = 0;
+            localIndex=0;
             limit_n = 0;
             num_each = num_each_query;
         } , cursor_mt )
@@ -96,16 +97,18 @@ end
 function cursor_methods:next()
     if self.limit_n > 0 and self.i >= self.limit_n then return nil end
 
-    local v = self.results [ self.i + 1 ]
+    local v = self.results [ self.localIndex + 1 ]
     if v ~= nil then
         self.i = self.i + 1
-        self.results [ self.i ] = nil
+        self.localIndex = self.localIndex +1
+        self.results [ self.localIndex ] = nil
         return self.i , v
     end
 
     if self.done then return nil end
 
     local t
+    self.localIndex  =0
     if not self.id then
         self.id, self.results, t = self.col:query(self.query, 
                         self.returnfields, self.i, self.num_each)


### PR DESCRIPTION
local servercount =mongoCollection:count({})
local cursor = mongoCollection:find({},{},0)
local count = 0	
for index, item in cursor:pairs() do
	count = count+1
end 
----out put
servercount = count+101  -- when total count is greater than 101
I found self.i didn't reset when self.resutls had been reassigned in cursor.lua file, so I add localIndex to solve it.



