### PR TITLE
fix when query is array table it may lead to syntax parse error

### DIFF
--- a/lib/resty/mongol/bson.lua
+++ b/lib/resty/mongol/bson.lua
@@ -186,7 +186,7 @@ function to_bson(ob)
 	elseif onlyarray then
 		local r = { }
 
-		local low = 0
+		local low = 1
 		--if seen_n [ 0 ] then low = 0 end
 		for i=low , high_n do
 			r [ i ] = pack ( i , seen_n [ i ] )


### PR DESCRIPTION
in lua, array index is start at 1 not 0 and t[0] is ignored by table.concat