### PR TITLE
ngx.worker.pid method is more efficient than ngx.var.pid and can be u…

### DIFF
--- a/lib/resty/mongol/object_id.lua
+++ b/lib/resty/mongol/object_id.lua
@@ -53,7 +53,7 @@ else
 end
 machineid = ngx.md5_bin(machineid):sub(1, 3)
 
-local pid = num_to_le_uint(bit.band(ngx.var.pid, 0xFFFF), 2)
+local pid = num_to_le_uint(bit.band(ngx.worker.pid(), 0xFFFF), 2)
 
 local inc = 0
 local function generate_id ( )


### PR DESCRIPTION
…sed in contexts where the ngx.var.VARIABLE API cannot be used (like init_worker_by_lua), see: https://github.com/openresty/lua-nginx-module#ngxworkerpid